### PR TITLE
Changed import of "Subject" to 'rxjs' to reduce bundle size

### DIFF
--- a/src/typeahead.component.ts
+++ b/src/typeahead.component.ts
@@ -2,11 +2,10 @@ import {
   Component, forwardRef, Input, OnDestroy, ElementRef, Output, OnChanges,
   EventEmitter, AfterViewInit, Inject, OnInit, Renderer2, HostListener, HostBinding, SimpleChanges, TemplateRef
 } from '@angular/core';
-import { Observable, Subscription, of } from 'rxjs';
+import { Observable, Subject, Subscription, of } from 'rxjs';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TypeaheadSettings, TypeaheadSuggestions } from './typeahead.interface';
 import { mergeAll, publishReplay, refCount, filter, toArray, mergeMap, debounceTime, take } from 'rxjs/operators';
-import { Subject } from 'rxjs/internal/Subject';
 
 const KEY_UP = 'keyup';
 const KEY_DOWN = 'keydown';
@@ -79,7 +78,7 @@ const sanitizeString = (text: string) =>
       <span *ngIf="!isDisabled" aria-hidden="true" (click)="removeValue(value)"
             [ngClass]="settings.tagRemoveIconClass">×</span>
     </span>
-    <input *ngIf="!isDisabled || !multi || !values.length" 
+    <input *ngIf="!isDisabled || !multi || !values.length"
            [disabled]="isDisabled || null"
            placeholder="{{(isDisabled || values.length) ? '' : placeholder}}"
            type="text" autocomplete="off"


### PR DESCRIPTION
The current import from 'rxjs/internal/Subject' will lead to a larger bundle size as the imports are not reused from the already included namespace.

Before:
![image](https://user-images.githubusercontent.com/13963492/56080549-aef8d780-5e02-11e9-83f1-e7ff2aec391c.png)

Please notice the duplicate "internal" block.

After:
![image](https://user-images.githubusercontent.com/13963492/56080554-bc15c680-5e02-11e9-843f-b33223cce7d9.png)
